### PR TITLE
feat: send harvest message when published concept is patched

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/Application.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/Application.kt
@@ -3,9 +3,11 @@ package no.fdk.concept_catalog
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 open class Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptPublisher.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptPublisher.kt
@@ -1,17 +1,46 @@
 package no.fdk.concept_catalog.service
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import no.fdk.concept_catalog.model.DataSource
 import no.fdk.concept_catalog.model.DataSourceType
 import no.fdk.concept_catalog.model.DataType
 import org.springframework.amqp.core.AmqpTemplate
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.AmqpException
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import java.util.*
 
 private val logger = LoggerFactory.getLogger(ConceptPublisher::class.java)
 
+private val publishersQueue: Queue<String> = LinkedList()
+
 @Service
 class ConceptPublisher(private val rabbitTemplate: AmqpTemplate) {
+
+    @Scheduled(fixedRate = 30000)
+    private fun pollQueue() {
+        if (publishersQueue.isNotEmpty()) {
+            sendHarvestMessage(publishersQueue.poll())
+        }
+    }
+
+    fun send(publisherId: String) {
+        if (!publishersQueue.contains(publisherId)) {
+            publishersQueue.add(publisherId)
+        }
+    }
+
+    private fun sendHarvestMessage(publisherId: String) {
+        val payload = JsonNodeFactory.instance.objectNode()
+        payload.put("publisherId", publisherId)
+        try {
+            rabbitTemplate.convertAndSend("harvests", "concept.publisher.HarvestTrigger", payload)
+            logger.info("Successfully sent harvest message for publisher {}", publisherId)
+        } catch (e: AmqpException) {
+            logger.error("Failed to send harvest message for publisher {}", publisherId, e)
+        }
+    }
 
     fun sendNewDataSource(publisherId: String, harvestUrl: String) {
         val dataSource = DataSource(

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -74,6 +74,10 @@ class ConceptService(
             throw ResponseStatusException(HttpStatus.CONFLICT)
         }
 
+        if (patched.status == Status.PUBLISERT || concept.status == Status.PUBLISERT) {
+            concept.ansvarligVirksomhet?.id?.let { publisherId -> conceptPublisher.send(publisherId) }
+        }
+
         return conceptRepository.save(patched)
     }
 


### PR DESCRIPTION
resolves #13

Ble enig med @stigbd om å legge til en buffer for høstemeldingene, så slipper vi at den sender tusenvis av meldinger hver gang noen endrer en setning på et publisert begrep.