### PR TITLE
feat: add begrepsrelasjon to specification

### DIFF
--- a/src/main/resources/specification/specification.yaml
+++ b/src/main/resources/specification/specification.yaml
@@ -356,6 +356,37 @@ components:
             type: string
         tildeltBruker:
           $ref: "#/components/schemas/Bruker"
+        begrepsRelasjon:
+          type: array
+          items:
+            $ref: "#/components/schemas/BegrepsRelasjon"
+    BegrepsRelasjon:
+      type: object
+      properties:
+        relasjon:
+          type: string
+          enum:
+            - assosiativ
+            - partitiv
+            - generisk
+            - seOgsaa
+            - erstattesAv
+        relasjonsType:
+          type: string
+          enum:
+            - overordnet
+            - underordnet
+        sistOppdatert:
+          type: string
+          format: date
+          nullable: false
+        beskrivelse:
+          $ref: '#/components/schemas/TekstMedSpraakKode'
+        inndelingskriterium:
+          $ref: '#/components/schemas/TekstMedSpraakKode'
+        related:
+          type: string
+          description: id of the related concept
     Kildebeskrivelse:
       type: object
       required:


### PR DESCRIPTION
Legger til "begrepsrelasjon" etter slik det er vist i UML og dels i "Informasjonsforvaltning/concepttordf".
Feltnavn for "overordnet" og "underordnet" følger feltnavn i "Informasjonsforvaltning/concepttordf" som "specializes", "generalizes", "hasPart" og "isPartOf". Alternativt kalle det "underordnet" og "overordnet" her?


https://data.norge.no/specification/forvaltningsstandard-begrepsbeskrivelser/images/UML-v2.0.png:

![image](https://user-images.githubusercontent.com/6214701/146378411-d4bdefba-51e6-4637-9c75-b201a4be46d1.png)
