### PR TITLE
fix: return all concepts on empty query

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptSearchService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptSearchService.kt
@@ -20,7 +20,7 @@ class ConceptSearchService(
     private fun SearchOperation.toMongoQuery(orgNumber: String): Query {
         val searchCriteria = Criteria.where("ansvarligVirksomhet.id").`is`(orgNumber)
 
-        if (query != null) searchCriteria.orOperator(fields.queryCriteria(query))
+        if (!query.isNullOrBlank()) searchCriteria.orOperator(fields.queryCriteria(query))
 
         if (filters?.status != null) {
             val statuses = filters.status.value.map { statusFromString(it) }

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/SearchConcepts.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/SearchConcepts.kt
@@ -186,6 +186,21 @@ class SearchConcepts : ApiTestContext() {
     }
 
     @Test
+    fun `Empty query returns all`() {
+        val queryFields = QueryFields(definisjon = false, anbefaltTerm = false, frarådetTerm = false, tillattTerm = false)
+        val response = authorizedRequest(
+            "/begreper/search?orgNummer=123456789",
+            port, mapper.writeValueAsString(SearchOperation("", fields = queryFields)), JwtToken(Access.ORG_WRITE).toString(),
+            HttpMethod.POST
+        )
+
+        assertEquals(HttpStatus.OK.value(), response["status"])
+
+        val titleResult: Paginated = mapper.readValue(response["body"] as String)
+        assertEquals(listOf(BEGREP_1, BEGREP_0, BEGREP_2, BEGREP_0_OLD), titleResult.hits)
+    }
+
+    @Test
     fun `Query returns correct results when searching in tillattTerm`() {
         val queryFields = QueryFields(definisjon = false, merknad = false, frarådetTerm = false, anbefaltTerm = false)
         val rsp = authorizedRequest(


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/concept-catalog/issues/183