### PR TITLE
fix: default true for current version filter

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/model/SearchOperation.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/model/SearchOperation.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 class SearchOperation(
     val query: String?,
     val fields: QueryFields = QueryFields(),
-    val filters: SearchFilters? = null,
+    val filters: SearchFilters = SearchFilters(),
     val sort: SortField = SortField(),
     val pagination: Pagination = Pagination()
 )
@@ -25,7 +25,7 @@ class QueryFields(
 class SearchFilters(
     val status: SearchFilter? = null,
     val published: BooleanFilter? = null,
-    val onlyCurrentVersions: Boolean = false
+    val onlyCurrentVersions: Boolean = true
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptSearchService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptSearchService.kt
@@ -22,14 +22,14 @@ class ConceptSearchService(
 
         if (!query.isNullOrBlank()) searchCriteria.orOperator(fields.queryCriteria(query))
 
-        if (filters?.status != null) {
+        if (filters.status != null) {
             val statuses = filters.status.value.map { statusFromString(it) }
             searchCriteria.andOperator(
                 Criteria.where("status").`in`(statuses)
             )
         }
 
-        if (filters?.published != null) {
+        if (filters.published != null) {
             searchCriteria.andOperator(
                 Criteria.where("erPublisert").`is`(filters.published.value)
             )

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -202,7 +202,7 @@ class ConceptService(
     fun searchConcepts(orgNumber: String, search: SearchOperation): Paginated =
         conceptSearchService.searchConcepts(orgNumber, search)
             .map { it.withHighestVersionDTO() }
-            .filter { if(search.filters?.onlyCurrentVersions == true) it.isCurrentVersion() else true }
+            .filter { if(search.filters.onlyCurrentVersions) it.isCurrentVersion() else true }
             .toList()
             .paginate(search.pagination)
 


### PR DESCRIPTION
La merke til at trefflista var feil i staging, den viste flere versjoner av samme begrep. Tenker dette blir enklest, nå slipper vi å definere onlyCurrentVersions for nesten alle søk 

fixes #191