### PR TITLE
fix: copy creation info from original when creating revision

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
@@ -93,7 +93,7 @@ class ChangeRequestService(
                 .updateLastChangedAndByWhom(user)
                 .also { currentConceptRepository.save(CurrentConcept(it)) }
                 .let { conceptRepository.save(it) }
-            dbConcept.erPublisert -> dbConcept.createNewRevision(user)
+            dbConcept.erPublisert -> dbConcept.createNewRevision()
                 .updateLastChangedAndByWhom(user)
                 .let { conceptRepository.save(it) }
             else -> dbConcept

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptMappers.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptMappers.kt
@@ -112,16 +112,14 @@ fun incrementSemVer(semVer: SemVer?): SemVer =
         patch = semVer?.patch?.let { it + 1 } ?: NEW_CONCEPT_VERSION.patch
     )
 
-fun BegrepDBO.createNewRevision(user: User): BegrepDBO =
+fun BegrepDBO.createNewRevision(): BegrepDBO =
     copy(
         id = UUID.randomUUID().toString(),
         versjonsnr = incrementSemVer(versjonsnr),
         revisjonAv = id,
         status = Status.UTKAST,
         erPublisert = false,
-        publiseringsTidspunkt = null,
-        opprettet = Instant.now(),
-        opprettetAv = user.name
+        publiseringsTidspunkt = null
     )
 
 fun createNewConcept(org: Virksomhet, user: User): BegrepDBO {

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -92,7 +92,7 @@ class ConceptService(
         )
 
     fun createRevisionOfConcept(revisionValues: Begrep, concept: BegrepDBO, user: User, jwt: Jwt): Begrep {
-        val newRevision = concept.createNewRevision(user).updateLastChangedAndByWhom(user)
+        val newRevision = concept.createNewRevision().updateLastChangedAndByWhom(user)
         val newWithUpdatedValues = newRevision.addUpdatableFieldsFromDTO(revisionValues)
 
         if(!newWithUpdatedValues.validateVersionUpgrade(concept.versjonsnr)) {

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
@@ -439,8 +439,6 @@ class ChangeRequests : ApiTestContext() {
                 publiseringsTidspunkt = null,
                 revisjonAv = BEGREP_0.id,
                 revisjonAvSistPublisert = true,
-                opprettet = result.opprettet,
-                opprettetAv = "TEST USER",
                 endringslogelement = Endringslogelement(endretAv = "TEST USER", endringstidspunkt = result.endringslogelement!!.endringstidspunkt),
                 status = Status.UTKAST,
                 assignedUser = "newUserId",


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/938

men må også utføre ETL for å få kopiert inn korrekt data i eksisterende revisjoner, dette fikser bare fremtidige