### PR TITLE
fix: set invalid paths for json-patch updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 *.iml
 .idea/
+.DS_Store

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
@@ -149,15 +149,8 @@ class ChangeRequestService(
         )
     }
 
-    private fun validateJsonPatchOperationsPaths(operations: List<JsonPatchOperation>) {
-        if (!jsonPatchOperationsPathsIsValid(operations)) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted")
-        }
-    }
-
     private fun validateJsonPatchOperations(concept: BegrepDBO, operations: List<JsonPatchOperation>) {
         try {
-            validateJsonPatchOperationsPaths(operations)
             patchOriginal(concept.copy(endringslogelement = null), operations, mapper)
         } catch (ex: Exception) {
             logger.error("failed to validate change request for concept ${concept.id}", ex)

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
@@ -150,9 +150,8 @@ class ChangeRequestService(
     }
 
     private fun validateJsonPatchOperationsPaths(operations: List<JsonPatchOperation>) {
-        val invalidPaths = listOf("/id", "/catalogId", "/conceptId", "/status")
-        if (operations.any { it.path in invalidPaths }) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of paths $invalidPaths is not permitted")
+        if (!jsonPatchOperationsPathsIsValid(operations)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted")
         }
     }
 

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -216,6 +216,10 @@ class ConceptService(
         operations: List<JsonPatchOperation>,
         user: User
     ): BegrepDBO {
+        if (!jsonPatchOperationsPathsIsValid(operations)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted")
+        }
+
         val patched = try {
             patchOriginal(concept.copy(endringslogelement = null), operations, mapper)
                 .copy(

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -216,10 +216,6 @@ class ConceptService(
         operations: List<JsonPatchOperation>,
         user: User
     ): BegrepDBO {
-        if (!jsonPatchOperationsPathsIsValid(operations)) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted")
-        }
-
         val patched = try {
             patchOriginal(concept.copy(endringslogelement = null), operations, mapper)
                 .copy(

--- a/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
@@ -43,3 +43,14 @@ inline fun <reified T> createPatchOperations(originalObject: T, updatedObject: T
 
         return readValue(Json.createDiff(original, updated).toString())
     }
+
+fun jsonPatchOperationsPathsIsValid(operations: List<JsonPatchOperation>): Boolean {
+    val invalidPaths = listOf(
+        "/id",
+        "/ansvarligVirksomhet",
+        "/originaltBegrep",
+        "/endringslogelement"
+    )
+
+    return operations.none { it.path in invalidPaths }
+}

--- a/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
@@ -11,6 +11,7 @@ import org.springframework.web.server.ResponseStatusException
 import java.io.StringReader
 
 inline fun <reified T> patchOriginal(original: T, operations: List<JsonPatchOperation>, mapper: ObjectMapper): T {
+    validateOperations(operations)
     try {
         return applyPatch(original, operations, mapper)
     } catch (ex: Exception) {
@@ -44,13 +45,14 @@ inline fun <reified T> createPatchOperations(originalObject: T, updatedObject: T
         return readValue(Json.createDiff(original, updated).toString())
     }
 
-fun jsonPatchOperationsPathsIsValid(operations: List<JsonPatchOperation>): Boolean {
+fun validateOperations(operations: List<JsonPatchOperation>) {
     val invalidPaths = listOf(
         "/id",
         "/ansvarligVirksomhet",
         "/originaltBegrep",
         "/endringslogelement"
     )
-
-    return operations.none { it.path in invalidPaths }
+    if (operations.any { it.path in invalidPaths }) {
+        throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of paths $invalidPaths is not permitted")
+    }
 }

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
@@ -437,7 +437,7 @@ class ChangeRequests : ContractTestsBase() {
 
         @Test
         fun badRequestWhenUpdatingIdFields() {
-            val errMsg = "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted"
+            val errMsg = "Patch of paths [/id, /ansvarligVirksomhet, /originaltBegrep, /endringslogelement] is not permitted"
 
             val illegalIdReplace = CHANGE_REQUEST_UPDATE_BODY_0.copy(
                 operations = listOf(

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
@@ -437,7 +437,7 @@ class ChangeRequests : ContractTestsBase() {
 
         @Test
         fun badRequestWhenUpdatingIdFields() {
-            val errMsg = "Patch of paths [/id, /catalogId, /conceptId, /status] is not permitted"
+            val errMsg = "Patch of id, ansvarligVirksomhet, originaltBegrep and endringslogelement is not permitted"
 
             val illegalIdReplace = CHANGE_REQUEST_UPDATE_BODY_0.copy(
                 operations = listOf(
@@ -466,8 +466,8 @@ class ChangeRequests : ContractTestsBase() {
                 operations = listOf(
                     JsonPatchOperation(
                         op = OpEnum.REPLACE,
-                        "/catalogId",
-                        "123456"
+                        "/ansvarligVirksomhet",
+                        mapOf(Pair("id", "123456"))
                     )
                 )
             )
@@ -489,7 +489,7 @@ class ChangeRequests : ContractTestsBase() {
                 operations = listOf(
                     JsonPatchOperation(
                         op = OpEnum.ADD,
-                        "/conceptId",
+                        "/originaltBegrep",
                         "123456"
                     )
                 )


### PR DESCRIPTION
Valideringen av paths i operations som gjøres for endringsforslag gjelder ikke for begrep...

Endret de til paths som er relevante for begrep og la til lignende validering i vanlig oppdatering av begrep