### PR TITLE
fix: always use DTO as original when applying json-patch

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ChangeRequestService.kt
@@ -151,7 +151,13 @@ class ChangeRequestService(
 
     private fun validateJsonPatchOperations(concept: BegrepDBO, operations: List<JsonPatchOperation>) {
         try {
-            patchOriginal(concept.copy(endringslogelement = null), operations, mapper)
+            concept.addUpdatableFieldsFromDTO(
+                patchOriginal(
+                    concept.copy(endringslogelement = null).toDTO(),
+                    operations,
+                    mapper
+                )
+            )
         } catch (ex: Exception) {
             logger.error("failed to validate change request for concept ${concept.id}", ex)
             throw ex

--- a/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/ConceptService.kt
@@ -217,11 +217,13 @@ class ConceptService(
         user: User
     ): BegrepDBO {
         val patched = try {
-            patchOriginal(concept.copy(endringslogelement = null), operations, mapper)
-                .copy(
-                    id = concept.id,
-                    originaltBegrep = concept.originaltBegrep,
-                    ansvarligVirksomhet = concept.ansvarligVirksomhet
+            concept
+                .addUpdatableFieldsFromDTO(
+                    patchOriginal(
+                        concept.toDTO(),
+                        operations,
+                        mapper
+                    )
                 )
                 .updateLastChangedAndByWhom(user)
         } catch (ex: Exception) {

--- a/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/service/JsonPatchUtils.kt
@@ -50,7 +50,9 @@ fun validateOperations(operations: List<JsonPatchOperation>) {
         "/id",
         "/ansvarligVirksomhet",
         "/originaltBegrep",
-        "/endringslogelement"
+        "/endringslogelement",
+        "/publiseringsTidspunkt",
+        "/erPublisert"
     )
     if (operations.any { it.path in invalidPaths }) {
         throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Patch of paths $invalidPaths is not permitted")

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/ChangeRequests.kt
@@ -437,7 +437,7 @@ class ChangeRequests : ContractTestsBase() {
 
         @Test
         fun badRequestWhenUpdatingIdFields() {
-            val errMsg = "Patch of paths [/id, /ansvarligVirksomhet, /originaltBegrep, /endringslogelement] is not permitted"
+            val errMsg = "Patch of paths [/id, /ansvarligVirksomhet, /originaltBegrep, /endringslogelement, /publiseringsTidspunkt, /erPublisert] is not permitted"
 
             val illegalIdReplace = CHANGE_REQUEST_UPDATE_BODY_0.copy(
                 operations = listOf(

--- a/src/test/kotlin/no/fdk/concept_catalog/contract/UpdateConcept.kt
+++ b/src/test/kotlin/no/fdk/concept_catalog/contract/UpdateConcept.kt
@@ -190,27 +190,6 @@ class UpdateConcept : ContractTestsBase() {
     }
 
     @Test
-    fun `Bad request when concept is published`() {
-        mongoOperations.insert(BEGREP_0.toDBO())
-
-        val operations = listOf(
-            JsonPatchOperation(
-                op = OpEnum.ADD,
-                path = "/kildebeskrivelse",
-                value = Kildebeskrivelse(ForholdTilKildeEnum.EGENDEFINERT, emptyList())
-            )
-        )
-
-        val response = authorizedRequest(
-            "/begreper/${BEGREP_0.id}",
-            mapper.writeValueAsString(operations),
-            JwtToken(Access.ORG_WRITE).toString(), HttpMethod.PATCH
-        )
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-    }
-
-    @Test
     fun `Bad request when trying to publish as part of normal update`() {
         mongoOperations.insert(BEGREP_TO_BE_UPDATED.toDBO())
 


### PR DESCRIPTION
vi ender opp med noen edgecases der frontend oppretter feil type operasjon i forhold til BegrepDBO, siden objektet som sendes til frontend har en del default-verdier som databaseobjektet ikke kjenner til. Så kjører toDTO() før patchOriginal og transformerer tilbake til DBO etterpå

Testen jeg fjerner fikk bad request pga bugen jeg fikser, lengre ned har vi testen `Patch of published concept creates new revision` som tester akkurat det samme, men med korrekt oppførsel. Så fjerna.

La også til publiseringsTidspunkt og erPublisert som invalidPath, tenkte det var greit å fortsette å få bad-request på de, i stedet for å bare bli ignorert som hadde vært resultat av fiksen uten å legge de til som invalid