### PR TITLE
fix: build import result URI safely

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/controller/ImportController.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/controller/ImportController.kt
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.*
-import java.net.URI
+import org.springframework.web.util.UriComponentsBuilder
 import java.util.concurrent.Executor
 
 @CrossOrigin
@@ -38,7 +38,8 @@ class ImportController(@Qualifier("import-executor") private val importExecutor:
             else -> {
                 importService.cancelImport(importId)
                 ResponseEntity
-                    .created(URI("/import/$catalogId/results/${importId}"))
+                    .created(UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}")
+                        .buildAndExpand(catalogId, importId).toUri())
                     .build()
             }
         }
@@ -60,7 +61,8 @@ class ImportController(@Qualifier("import-executor") private val importExecutor:
             else -> {
                 importService.addConceptToCatalog(catalogId, importId, externalId, user, jwt)
                 return ResponseEntity
-                    .created(URI("/import/$catalogId/results/${importId}"))
+                    .created(UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}")
+                        .buildAndExpand(catalogId, importId).toUri())
                     .build()
 
             }
@@ -86,7 +88,8 @@ class ImportController(@Qualifier("import-executor") private val importExecutor:
             else -> {
                 val importResult = importService.createImportResult(catalogId)
                 return ResponseEntity
-                    .created(URI("/import/$catalogId/results/${importResult.id}"))
+                    .created(UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}")
+                        .buildAndExpand(catalogId, importResult.id).toUri())
                     .build()
             }
         }
@@ -127,7 +130,8 @@ class ImportController(@Qualifier("import-executor") private val importExecutor:
                 }
 
                 ResponseEntity
-                    .created(URI("/import/$catalogId/results/${importId}"))
+                    .created(UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}")
+                        .buildAndExpand(catalogId, importId).toUri())
                     .build()
             }
         }
@@ -157,7 +161,8 @@ class ImportController(@Qualifier("import-executor") private val importExecutor:
                 }
 
                 return ResponseEntity
-                    .created(URI("/import/$catalogId/results/${importId}"))
+                    .created(UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}")
+                        .buildAndExpand(catalogId, importId).toUri())
                     .build()
             }
         }


### PR DESCRIPTION
  Root cause: catalogId and importId are user-supplied path variables that were interpolated directly into URI("...") strings, which then
   become the Location response header. A crafted value containing special characters could inject into the header (header injection /   
  reflected XSS vector).                                                                                                                 
                                                                                                                                         
  Fix: Replaced all five URI("/import/$catalogId/results/${importId}") calls with                                                        
  UriComponentsBuilder.fromPath("/import/{catalogId}/results/{importId}").buildAndExpand(catalogId, importId).toUri(). Spring's          
  UriComponentsBuilder percent-encodes the expanded variables, neutralizing any injected characters. Also removed the now-unused import  
  java.net.URI.       