### PR TITLE
fix: configure Hibernate to use Spring ObjectMapper for JSONB

### DIFF
--- a/src/main/kotlin/no/fdk/concept_catalog/configuration/JacksonConfigurer.kt
+++ b/src/main/kotlin/no/fdk/concept_catalog/configuration/JacksonConfigurer.kt
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.hibernate.type.format.jackson.JacksonJsonFormatMapper
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -24,4 +26,10 @@ class JacksonConfigurer {
             .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
     }
+
+    @Bean
+    fun hibernateJsonFormatMapper(objectMapper: ObjectMapper): HibernatePropertiesCustomizer =
+        HibernatePropertiesCustomizer { props ->
+            props["hibernate.type.json_format_mapper"] = JacksonJsonFormatMapper(objectMapper)
+        }
 }


### PR DESCRIPTION
# Summary

- Registers a HibernatePropertiesCustomizer that makes Hibernate use the Spring @Primary ObjectMapper for JSONB serialisation/deserialisation
- Resolves "Unparseable date" errors caused by Hibernate's default ObjectMapper lacking JavaTimeModule and the Kotlin module